### PR TITLE
Optional feature: cleanly track functions/objects from multiple external packages 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,7 @@ Suggests:
   keras (>= 2.2.5.0),
   knitr (>= 1.30),
   rmarkdown (>= 2.4),
+  pkgload (>= 1.1.0),
   qs (>= 0.23.2),
   rstudioapi (>= 0.11),
   testthat (>= 3.0.0),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,8 @@
 S3method(hash_object,"function")
 S3method(hash_object,character)
 S3method(hash_object,default)
+S3method(imports_init,default)
+S3method(imports_init,tar_imports)
 S3method(pipeline_validate,default)
 S3method(pipeline_validate,tar_pipeline)
 S3method(pipeline_validate_lite,default)

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Add new dynamic branching patterns `head()`, `tail()`, and `sample()` to provide functionality equivalent to `drake`'s `max_expand` (#56).
 * Add a new `tar_pattern()` function to emulate dynamic branching outside a pipeline.
 * Add a new `level_separation` argument to `tar_visnetwork()` and `tar_glimpse()` to control the aspect ratio (#226).
+* Track functions from multiple packages with the `imports` argument to `tar_option_set()` (#239).
 
 ## Enhancements
 

--- a/R/class_active.R
+++ b/R/class_active.R
@@ -24,7 +24,7 @@ active_class <- R6::R6Class(
     ensure_meta = function() {
       self$meta$validate()
       self$meta$database$preprocess(write = TRUE)
-      self$meta$record_imports(self$pipeline$envir, self$pipeline)
+      self$meta$record_imports(self$pipeline$imports, self$pipeline)
       self$meta$restrict_records(self$pipeline)
     },
     produce_exports = function(envir) {
@@ -50,7 +50,7 @@ active_class <- R6::R6Class(
     process_target = function(name) {
       target <- pipeline_get_target(self$pipeline, name)
       target_debug(target)
-      target_update_depend(target, meta)
+      target_update_depend(target, self$pipeline, self$meta)
       trn(
         target_should_run(target, self$meta),
         self$run_target(name),

--- a/R/class_branch.R
+++ b/R/class_branch.R
@@ -63,7 +63,7 @@ target_get_type.tar_branch <- function(target) {
 }
 
 #' @export
-target_produce_record.tar_branch <- function(target, meta) {
+target_produce_record.tar_branch <- function(target, pipeline, meta) {
   file <- target$store$file
   record_init(
     name = target_get_name(target),

--- a/R/class_builder.R
+++ b/R/class_builder.R
@@ -20,12 +20,12 @@ builder_new <- function(
 }
 
 #' @export
-target_update_depend.tar_builder <- function(target, meta) {
+target_update_depend.tar_builder <- function(target, pipeline, meta) {
   depends <- meta$depends
   memory_set_object(
     depends,
     target_get_name(target),
-    meta$produce_depend(target)
+    meta$produce_depend(target, pipeline)
   )
 }
 
@@ -116,7 +116,7 @@ builder_conclude <- function(target, pipeline, scheduler, meta) {
   builder_ensure_object(target, "main")
   builder_wait_correct_hash(target)
   target_ensure_buds(target, pipeline, scheduler)
-  meta$insert_record(target_produce_record(target, meta))
+  meta$insert_record(target_produce_record(target, pipeline, meta))
   target_patternview_meta(target, pipeline, meta)
   pipeline_register_loaded(pipeline, target_get_name(target))
   scheduler$progress$register_built(target_get_name(target))
@@ -124,7 +124,7 @@ builder_conclude <- function(target, pipeline, scheduler, meta) {
 
 builder_error <- function(target, pipeline, scheduler, meta) {
   target_restore_buds(target, pipeline, scheduler, meta)
-  builder_record_error_meta(target, meta)
+  builder_record_error_meta(target, pipeline, meta)
   target_patternview_meta(target, pipeline, meta)
   builder_handle_error(target, pipeline, scheduler, meta)
 }
@@ -230,8 +230,8 @@ builder_save_workspace <- function(target, pipeline, scheduler) {
   workspace_save(workspace_init(target, pipeline))
 }
 
-builder_record_error_meta <- function(target, meta) {
-  record <- target_produce_record(target, meta)
+builder_record_error_meta <- function(target, pipeline, meta) {
+  record <- target_produce_record(target, pipeline, meta)
   meta$handle_error(record)
   meta$insert_record(record)
 }

--- a/R/class_glimpse.R
+++ b/R/class_glimpse.R
@@ -66,7 +66,7 @@ glimpse_class <- R6::R6Class(
       )
     },
     update_imports = function() {
-      envir <- self$pipeline$envir
+      envir <- self$pipeline$imports
       graph <- graph_envir(envir)
       edges <- lapply(as_data_frame(igraph::get.edgelist(graph)), as.character)
       edges <- data_frame(from = edges[[1]], to = edges[[2]])
@@ -99,7 +99,7 @@ glimpse_class <- R6::R6Class(
         bytes = rep(NA_real_, length(names)),
         branches = rep(NA_integer_, length(names))
       )
-      names <- c(names, names(self$pipeline$envir))
+      names <- c(names, names(self$pipeline$imports))
       edges <- pipeline_upstream_edges(self$pipeline, targets_only = FALSE)
       edges <- edges[edges$from %in% names & edges$to %in% names,, drop = FALSE] # nolint
       edges <- edges[edges$from != edges$to,, drop = FALSE] # nolint

--- a/R/class_imports.R
+++ b/R/class_imports.R
@@ -1,0 +1,30 @@
+imports_init <- function(envir) {
+  UseMethod("imports_init")
+}
+
+#' @export
+imports_init.tar_imports <- function(envir) {
+  envir
+}
+
+#' @export
+imports_init.default <- function(envir) {
+  imports <- new.env(parent = emptyenv())
+  packages <- rev(tar_option_get("imports"))
+  map(packages, ~import_envir(from = getNamespace(.x), into = imports))
+  import_envir(from = envir, into = imports)
+  enclass(imports, "tar_imports")
+}
+
+import_envir <- function(from, into) {
+  lapply(names(from), import_object, from = from, into = into)
+}
+
+import_object <- function(name, from, into) {
+  assign(
+    x = name,
+    value = get(name, envir = from, inherits = FALSE),
+    envir = into,
+    inherits = FALSE
+  )
+}

--- a/R/class_imports.R
+++ b/R/class_imports.R
@@ -11,9 +11,13 @@ imports_init.tar_imports <- function(envir) {
 imports_init.default <- function(envir) {
   imports <- new.env(parent = emptyenv())
   packages <- rev(tar_option_get("imports"))
-  map(packages, ~import_envir(from = getNamespace(.x), into = imports))
+  lapply(packages, import_set_package, imports = imports)
   import_envir(from = envir, into = imports)
-  enclass(imports, "tar_imports")
+  imports_new(imports)
+}
+
+imports_new <- function(envir) {
+  enclass(envir, "tar_imports")
 }
 
 imports_set_package <- function(imports, package) {

--- a/R/class_imports.R
+++ b/R/class_imports.R
@@ -11,8 +11,8 @@ imports_init.tar_imports <- function(envir) {
 imports_init.default <- function(envir) {
   imports <- new.env(parent = emptyenv())
   packages <- rev(tar_option_get("imports"))
-  lapply(packages, import_set_package, imports = imports)
-  import_envir(from = envir, into = imports)
+  lapply(packages, imports_set_package, imports = imports)
+  imports_set_envir(imports = imports, envir = envir)
   imports_new(imports)
 }
 

--- a/R/class_imports.R
+++ b/R/class_imports.R
@@ -16,15 +16,25 @@ imports_init.default <- function(envir) {
   enclass(imports, "tar_imports")
 }
 
-import_envir <- function(from, into) {
-  lapply(names(from), import_object, from = from, into = into)
+imports_set_package <- function(imports, package) {
+  envir <- getNamespace(package)
+  imports_set_envir(imports, envir)
 }
 
-import_object <- function(name, from, into) {
+imports_set_envir <- function(imports, envir) {
+  lapply(names(envir), imports_set_object, imports = imports, envir = envir)
+}
+
+imports_set_object <- function(imports, name, envir) {
   assign(
     x = name,
-    value = get(name, envir = from, inherits = FALSE),
-    envir = into,
+    value = get(name, envir = envir, inherits = FALSE),
+    envir = imports,
     inherits = FALSE
   )
+}
+
+imports_validate <- function(imports) {
+  assert_inherits(imports, "tar_imports")
+  assert_envir(imports)
 }

--- a/R/class_inspection.R
+++ b/R/class_inspection.R
@@ -166,7 +166,7 @@ inspection_class <- R6::R6Class(
       merge(vertices, meta, all.x = TRUE, sort = FALSE)
     },
     update_imports = function() {
-      envir <- self$pipeline$envir
+      envir <- self$pipeline$imports
       graph <- graph_envir(envir)
       edges <- lapply(as_data_frame(igraph::get.edgelist(graph)), as.character)
       edges <- data_frame(from = edges[[1]], to = edges[[2]])
@@ -181,7 +181,7 @@ inspection_class <- R6::R6Class(
       vertices <- data_frame(name = names)
       vertices <- self$resolve_target_status(vertices)
       vertices <- self$resolve_target_meta(vertices)
-      names <- c(names, names(self$pipeline$envir))
+      names <- c(names, names(self$pipeline$imports))
       edges <- pipeline_upstream_edges(self$pipeline, targets_only = FALSE)
       edges <- edges[edges$from %in% names & edges$to %in% names,, drop = FALSE] # nolint
       edges <- edges[edges$from != edges$to,, drop = FALSE] # nolint

--- a/R/class_outdated.R
+++ b/R/class_outdated.R
@@ -88,7 +88,7 @@ outdated_class <- R6::R6Class(
         target_skip(target, self$pipeline, self$scheduler, self$meta),
         error = function(e) warning(e$message)
       )
-      target_update_depend(target, self$meta)
+      target_update_depend(target, self$pipeline, self$meta)
       if (target_should_run(target, self$meta)) {
         self$register_builder_outdated(target)
       }

--- a/R/class_passive.R
+++ b/R/class_passive.R
@@ -23,7 +23,7 @@ passive_class <- R6::R6Class(
   public = list(
     ensure_meta = function() {
       self$meta$database$ensure_preprocessed(write = FALSE)
-      self$meta$set_imports(self$pipeline$envir, self$pipeline)
+      self$meta$set_imports(self$pipeline$imports, self$pipeline)
       self$meta$restrict_records(self$pipeline)
     },
     start = function() {

--- a/R/class_pattern.R
+++ b/R/class_pattern.R
@@ -28,11 +28,11 @@ target_get_children.tar_pattern <- function(target) {
 }
 
 #' @export
-target_produce_record.tar_pattern <- function(target, meta) {
+target_produce_record.tar_pattern <- function(target, pipeline, meta) {
   record_init(
     name = target_get_name(target),
     type = target_get_type(target),
-    data = pattern_produce_data_hash(target, meta),
+    data = pattern_produce_data_hash(target, pipeline, meta),
     command = target$command$hash,
     bytes = target$patternview$bytes,
     format = target$settings$format,
@@ -83,7 +83,7 @@ target_branches_over.tar_pattern <- function(target, name) {
 }
 
 #' @export
-target_update_depend.tar_pattern <- function(target, meta) {
+target_update_depend.tar_pattern <- function(target, pipeline, meta) {
   depends <- meta$depends
   memory_set_object(depends, target_get_name(target), null64)
 }
@@ -219,8 +219,8 @@ pattern_priority <- function() {
   1.1
 }
 
-pattern_produce_data_hash <- function(target, meta) {
-  hash_branches <- meta$hash_deps(target_get_children(target))
+pattern_produce_data_hash <- function(target, pipeline, meta) {
+  hash_branches <- meta$hash_deps(target_get_children(target), pipeline)
   digest_chr64(paste(target$settings$iteration, hash_branches))
 }
 
@@ -232,7 +232,7 @@ pattern_conclude_initial <- function(target, pipeline, scheduler, meta) {
 
 pattern_conclude_final <- function(target, pipeline, scheduler, meta) {
   pattern_skip_final(target, pipeline, scheduler, meta)
-  pattern_record_meta(target, meta)
+  pattern_record_meta(target, pipeline, meta)
   patternview_register_final(target$patternview, target, scheduler)
 }
 
@@ -273,14 +273,14 @@ pipeline_assert_dimension <- function(target, pipeline, name) {
   }
 }
 
-pattern_record_meta <- function(target, meta) {
+pattern_record_meta <- function(target, pipeline, meta) {
   name <- target_get_name(target)
   old_data <- trn(
     meta$exists_record(name),
     meta$get_record(name)$data,
     NA_character_
   )
-  record <- target_produce_record(target, meta)
+  record <- target_produce_record(target, pipeline, meta)
   if (!identical(record$data, old_data)) {
     meta$insert_record(record)
   }

--- a/R/class_sitrep.R
+++ b/R/class_sitrep.R
@@ -67,7 +67,7 @@ sitrep_class <- R6::R6Class(
     process_builder = function(target) {
       name <- target_get_name(target)
       target <- pipeline_get_target(self$pipeline, name)
-      target_update_depend(target, meta)
+      target_update_depend(target, self$pipeline, self$meta)
       self$sitrep[[name]] <- builder_sitrep(target, self$meta)
       trn(
         self$meta$exists_record(target_get_name(target)),

--- a/R/class_stem.R
+++ b/R/class_stem.R
@@ -55,7 +55,7 @@ target_produce_junction.tar_stem <- function(target, pipeline) {
 }
 
 #' @export
-target_produce_record.tar_stem <- function(target, meta) {
+target_produce_record.tar_stem <- function(target, pipeline, meta) {
   file <- target$store$file
   record_init(
     name = target_get_name(target),

--- a/R/class_target.R
+++ b/R/class_target.R
@@ -204,7 +204,7 @@ target_read_value <- function(target, pipeline) {
   UseMethod("target_read_value")
 }
 
-target_produce_record <- function(target, meta) {
+target_produce_record <- function(target, pipeline, meta) {
   UseMethod("target_produce_record")
 }
 
@@ -281,7 +281,7 @@ target_restore_buds <- function(target, pipeline, scheduler, meta) {
   UseMethod("target_restore_buds")
 }
 
-target_update_depend <- function(target, meta) {
+target_update_depend <- function(target, pipeline, meta) {
   UseMethod("target_update_depend")
 }
 

--- a/R/tar_option_get.R
+++ b/R/tar_option_get.R
@@ -29,6 +29,7 @@ tar_option_default <- function(option) {
     option,
     tidy_eval = TRUE,
     packages = (.packages()),
+    imports = character(0),
     library = NULL,
     envir = globalenv(),
     format = "rds",

--- a/R/tar_option_set.R
+++ b/R/tar_option_set.R
@@ -7,6 +7,13 @@
 #'   `_targets.R` script before calls to [tar_target()] or [tar_target_raw()].
 #' @return Nothing.
 #' @inheritParams tar_target
+#' @param imports Character vector of package names to track
+#'   global dependencies. For example, if you write
+#'   `tar_option_set(imports = "yourAnalysisPackage")` early in `_targets.R`,
+#'   then `tar_make()` will automatically rerun or skip targets
+#'   in response to changes to the R functions and objects defined in
+#'   `yourAnalysisPackage`. Does not account for low-level compiled code
+#'   such as C/C++ or Fortran.
 #' @param envir Environment containing functions and global objects
 #'   used in the R commands to run targets.
 #' @param debug Character vector of names of targets to run in debug mode.
@@ -36,6 +43,7 @@
 tar_option_set <- function(
   tidy_eval = NULL,
   packages = NULL,
+  imports = NULL,
   library = NULL,
   envir = NULL,
   format = NULL,
@@ -55,6 +63,7 @@ tar_option_set <- function(
   force(envir)
   tar_option_set_tidy_eval(tidy_eval)
   tar_option_set_packages(packages)
+  tar_option_set_imports(imports)
   tar_option_set_library(library)
   tar_option_set_envir(envir)
   tar_option_set_format(format)
@@ -82,6 +91,12 @@ tar_option_set_packages <- function(packages) {
   packages <- packages %||% tar_option_get("packages")
   assert_chr(packages, "packages in tar_option_set() must be character.")
   assign("packages", packages, envir = tar_envir_options)
+}
+
+tar_option_set_imports <- function(imports) {
+  imports <- imports %||% tar_option_get("imports")
+  assert_chr(imports, "imports in tar_option_set() must be character.")
+  assign("imports", imports, envir = tar_envir_options)
 }
 
 tar_option_set_library <- function(library) {

--- a/R/tar_option_set.R
+++ b/R/tar_option_set.R
@@ -13,7 +13,11 @@
 #'   then `tar_make()` will automatically rerun or skip targets
 #'   in response to changes to the R functions and objects defined in
 #'   `yourAnalysisPackage`. Does not account for low-level compiled code
-#'   such as C/C++ or Fortran.
+#'   such as C/C++ or Fortran. If you supply multiple packages,
+#'   e.g. `tar_option_set(imports = c("p1", "p2"))`, then the objects in
+#'   `p1` override the objects in `p2` if there are name conflicts.
+#'   Similarly, objects in `tar_option_get("envir")` override
+#'   everything in `tar_option_get("imports")`.
 #' @param envir Environment containing functions and global objects
 #'   used in the R commands to run targets.
 #' @param debug Character vector of names of targets to run in debug mode.

--- a/R/tar_outdated.R
+++ b/R/tar_outdated.R
@@ -106,7 +106,7 @@ tar_outdated_inner <- function(
 
 tar_outdated_globals <- function(pipeline, meta) {
   meta$database$ensure_preprocessed(write = FALSE)
-  new <- hash_imports(pipeline$envir)
+  new <- hash_imports(pipeline$imports)
   new$new <- new$data
   recorded <- fltr(new$name, ~meta$exists_record(.x))
   if (!length(recorded)) {

--- a/R/utils_imports.R
+++ b/R/utils_imports.R
@@ -11,13 +11,13 @@ hash_imports_graph <- function(envir, graph) {
   data_frame(name = order, type = type, data = hash)
 }
 
+graph_envir <- function(envir) {
+  graph_edges(edges_envir(envir))
+}
+
 type_import <- function(name, envir) {
   object <- get(x = name, envir = envir, inherits = FALSE)
   ifelse(is.function(object), "function", "object")
-}
-
-graph_envir <- function(envir) {
-  graph_edges(edges_envir(envir))
 }
 
 graph_edges <- function(edges) {

--- a/man/tar_option_set.Rd
+++ b/man/tar_option_set.Rd
@@ -7,6 +7,7 @@
 tar_option_set(
   tidy_eval = NULL,
   packages = NULL,
+  imports = NULL,
   library = NULL,
   envir = NULL,
   format = NULL,
@@ -33,6 +34,14 @@ the values of global objects.}
 \item{packages}{Character vector of packages to load right before
 the target builds. Use \code{tar_option_set()} to set packages
 globally for all subsequent targets you define.}
+
+\item{imports}{Character vector of package names to track
+global dependencies. For example, if you write
+\code{tar_option_set(imports = "yourAnalysisPackage")} early in \verb{_targets.R},
+then \code{tar_make()} will automatically rerun or skip targets
+in response to changes to the R functions and objects defined in
+\code{yourAnalysisPackage}. Does not account for low-level compiled code
+such as C/C++ or Fortran.}
 
 \item{library}{Character vector of library paths to try
 when loading \code{packages}.}

--- a/man/tar_option_set.Rd
+++ b/man/tar_option_set.Rd
@@ -41,7 +41,11 @@ global dependencies. For example, if you write
 then \code{tar_make()} will automatically rerun or skip targets
 in response to changes to the R functions and objects defined in
 \code{yourAnalysisPackage}. Does not account for low-level compiled code
-such as C/C++ or Fortran.}
+such as C/C++ or Fortran. If you supply multiple packages,
+e.g. \code{tar_option_set(imports = c("p1", "p2"))}, then the objects in
+\code{p1} override the objects in \code{p2} if there are name conflicts.
+Similarly, objects in \code{tar_option_get("envir")} override
+everything in \code{tar_option_get("imports")}.}
 
 \item{library}{Character vector of library paths to try
 when loading \code{packages}.}

--- a/tests/testthat/test-class_branch.R
+++ b/tests/testthat/test-class_branch.R
@@ -150,7 +150,7 @@ tar_test("branch$produce_record() of a successful branch", {
   local$run()
   meta <- local$meta
   target <- pipeline_get_target(pipeline, target_get_children(map)[2L])
-  record <- target_produce_record(target, meta)
+  record <- target_produce_record(target, pipeline, meta)
   expect_silent(record_validate(record))
   expect_true(grepl("^y_", record$name))
   expect_equal(record$parent, "y")

--- a/tests/testthat/test-class_builder.R
+++ b/tests/testthat/test-class_builder.R
@@ -26,7 +26,7 @@ tar_test("target_run() on a errored builder", {
   x <- target_init(name = "abc", expr = quote(identity(identity(stop(123)))))
   target_run(x)
   meta <- meta_init()
-  target_update_depend(x, meta)
+  target_update_depend(x, pipeline_init(), meta)
   expect_error(
     target_conclude(x, pipeline_init(), scheduler_init(), meta),
     class = "condition_run"

--- a/tests/testthat/test-class_imports.R
+++ b/tests/testthat/test-class_imports.R
@@ -12,3 +12,18 @@ tar_test("imports_set_object()", {
   imports_set_object(imports = imports, name = "a", envir = envir)
   expect_equal(imports$a, "x")
 })
+
+tar_test("imports_set_envir()", {
+  imports <- imports_new(new.env(parent = emptyenv()))
+  envir <- new.env(parent = emptyenv())
+  envir$.a <- "x"
+  envir$b <- "y"
+  envir$c <- "z"
+  expect_null(imports$.a)
+  expect_null(imports$b)
+  expect_null(imports$c)
+  imports_set_envir(imports = imports,envir = envir)
+  expect_equal(imports$.a, "x")
+  expect_equal(imports$b, "y")
+  expect_equal(imports$c, "z")
+})

--- a/tests/testthat/test-class_imports.R
+++ b/tests/testthat/test-class_imports.R
@@ -1,9 +1,3 @@
-tar_test("imports_validate()", {
-  expect_silent(imports_validate(imports_new(new.env())))
-  expect_error(imports_validate(new.env()), class = "condition_validate")
-  expect_error(imports_validate(123), class = "condition_validate")
-})
-
 tar_test("imports_set_object()", {
   imports <- imports_new(new.env(parent = emptyenv()))
   envir <- new.env(parent = emptyenv())
@@ -27,3 +21,48 @@ tar_test("imports_set_envir()", {
   expect_equal(imports$b, "y")
   expect_equal(imports$c, "z")
 })
+
+tar_test("imports_set_package()", {
+  imports <- imports_new(new.env(parent = emptyenv()))
+  expect_null(imports$head)
+  imports_set_package(imports = imports, package = "utils")
+  expect_true(is.function(imports$head))
+})
+
+tar_test("imports_set_package()", {
+  imports <- imports_new(new.env(parent = emptyenv()))
+  expect_null(imports$head)
+  imports_set_package(imports = imports, package = "utils")
+  expect_true(is.function(imports$head))
+})
+
+tar_test("imports_init()", {
+  tar_option_set(imports = c("utils", "digest"))
+  envir <- new.env(parent = emptyenv())
+  envir$head <- "abc"
+  expect_null(envir$tail)
+  expect_null(envir$digest)
+  imports <- imports_init(envir)
+  expect_equal(imports$head, "abc")
+  expect_true(is.function(imports$tail))
+  expect_true(is.function(imports$digest))
+  expect_null(envir$tail)
+  expect_null(envir$digest)
+  expect_true(inherits(imports, "tar_imports"))
+  expect_false(inherits(envir, "tar_imports"))
+})
+
+tar_test("imports_init() idempotence", {
+  tar_option_set(imports = c("utils", "digest"))
+  imports <- imports_init(imports_new(new.env(parent = emptyenv())))
+  expect_true(inherits(imports, "tar_imports"))
+  expect_equal(length(imports), 0L)
+  expect_null(imports$head)
+})
+
+tar_test("imports_validate()", {
+  expect_silent(imports_validate(imports_new(new.env())))
+  expect_error(imports_validate(new.env()), class = "condition_validate")
+  expect_error(imports_validate(123), class = "condition_validate")
+})
+

--- a/tests/testthat/test-class_imports.R
+++ b/tests/testthat/test-class_imports.R
@@ -1,0 +1,14 @@
+tar_test("imports_validate()", {
+  expect_silent(imports_validate(imports_new(new.env())))
+  expect_error(imports_validate(new.env()), class = "condition_validate")
+  expect_error(imports_validate(123), class = "condition_validate")
+})
+
+tar_test("imports_set_object()", {
+  imports <- imports_new(new.env(parent = emptyenv()))
+  envir <- new.env(parent = emptyenv())
+  envir$a <- "x"
+  expect_null(imports$a)
+  imports_set_object(imports = imports, name = "a", envir = envir)
+  expect_equal(imports$a, "x")
+})

--- a/tests/testthat/test-class_meta.R
+++ b/tests/testthat/test-class_meta.R
@@ -31,7 +31,7 @@ tar_test("builder metadata recording", {
   db$reset_storage()
   data <- db$read_data()
   expect_equal(nrow(data), 0L)
-  meta$insert_record(target_produce_record(target, meta))
+  meta$insert_record(target_produce_record(target, pipeline, meta))
   expect_true(db$exists_row(target_get_name(target)))
   data <- db$read_data()
   expect_equal(nrow(data), 1L)
@@ -160,7 +160,7 @@ tar_test("meta$produce_depend() nonempty", {
   local <- local_init(pipeline)
   local$run()
   meta <- local$meta
-  out <- meta$produce_depend(y)
+  out <- meta$produce_depend(y, pipeline)
   expect_equal(length(out), 1L)
   expect_equal(nchar(out), 16L)
 })

--- a/tests/testthat/test-class_pattern.R
+++ b/tests/testthat/test-class_pattern.R
@@ -402,7 +402,7 @@ tar_test("pattern$produce_record() of a successful map", {
   local <- local_init(pipeline)
   local$run()
   meta <- local$meta
-  record <- target_produce_record(target, meta)
+  record <- target_produce_record(target, pipeline, meta)
   expect_silent(record_validate(record))
   expect_equal(record$name, "y")
   expect_equal(record$parent, NA_character_)

--- a/tests/testthat/test-class_stem.R
+++ b/tests/testthat/test-class_stem.R
@@ -119,7 +119,7 @@ tar_test("insert stem record of a successful stem", {
   db <- meta$database
   db$ensure_storage()
   db$reset_storage()
-  record <- target_produce_record(target, meta)
+  record <- target_produce_record(target, pipeline, meta)
   db$insert_row(record_produce_row(record))
   data <- db$read_data()
   expect_equal(data$name, "x")
@@ -145,7 +145,7 @@ tar_test("stem$produce_record() of a successful stem", {
   local <- local_init(pipeline)
   local$run()
   meta <- local$meta
-  record <- target_produce_record(target, meta)
+  record <- target_produce_record(target, pipeline, meta)
   expect_silent(record_validate(record))
   expect_equal(record$name, "x")
   expect_equal(record$parent, NA_character_)
@@ -170,7 +170,7 @@ tar_test("stem$produce_record() of a errored stem", {
   local <- local_init(pipeline)
   expect_error(local$run(), class = "condition_run")
   meta <- local$meta
-  record <- target_produce_record(target, meta)
+  record <- target_produce_record(target, pipeline, meta)
   expect_silent(record_validate(record))
   expect_equal(record$name, "x")
   expect_equal(record$parent, NA_character_)
@@ -195,7 +195,7 @@ tar_test("stem$produce_record() with no error message", {
   local <- local_init(pipeline)
   expect_error(local$run(), class = "condition_run")
   meta <- local$meta
-  record <- target_produce_record(target, meta)
+  record <- target_produce_record(target, pipeline, meta)
   expect_equal(record$error, ".")
 })
 

--- a/vignettes/need.Rmd
+++ b/vignettes/need.Rmd
@@ -57,6 +57,14 @@ However, nearly four years of community feedback have exposed major user-side li
 
 The `targets` package solves all these issues by design. Functions `tar_make()`, `tar_make_clustermq()`, and `tar_make_future()` all create fresh new R sessions by default. They all require a `_targets.R` configuration file in the project root (working directory of the `tar_make()` call) so that the functions, global objects, and settings are all populated in the exact same way each session, leading to less frustration, greater consistency, and greater reproducibility. In addition, the `_targets/` data store always lives in the project root.
 
+## Enhanced debugging support
+
+`targets` has enhanced debugging support. With the `workspaces` argument to `tar_option_set()`, users can locally recreate the conditions under which a target runs. This includes packages, global functions and objects, and the random number generator seed. Similarly, `tar_option_set(error = "workspace")` automatically saves debugging workspaces for targets that encounter errors. The `debug` option lets users enter an interactive debugger for a given target while the pipeline is running. And unlike `drake`, all debugging features are fully compatible with dynamic branching.
+
+## Improved tracking of package functions
+
+By default, `targets` ignores changes to functions inside external packages. However, if a workflow centers on a custom package with methodology under development, users can make `targets` automatically watch the package's functions for changes. Simply supply the names of the relevant packages to the `imports` argument of `tar_option_set()`. Unlike `drake`, `targets` can track multiple packages this way, and the internal mechanism is much safer.
+
 ## Lighter, friendlier data management
 
 [`drake`](https://github.com/ropensci/drake)'s cache is an intricate file system in a hidden `.drake` folder. It contains multiple files for each target, and those names are not informative. (See the files in the `data/` folder in the diagram below.) Users often have trouble understanding how [`drake`](https://github.com/ropensci/drake) manages data, resolving problems when files are corrupted, placing the data under version control, collaborating with others on the same pipeline, and clearing out superfluous data when the cache grows large in storage.


### PR DESCRIPTION
# Prework

* [x] I understand and agree to the [code of conduct](https://github.com/wlandau/targets/blob/main/CODE_OF_CONDUCT.md) and the [contributing guidelines](https://github.com/wlandau/targets/blob/main/CONTRIBUTING.md).
* [x] I have already submitted an issue to the [issue tracker](http://github.com/wlandau/targets/issues) to discuss my idea with the maintainer.
* [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).

# Related GitHub issues and pull requests

* Ref: #239

# Summary

By default, `targets` ignores changes to functions inside external packages. However, if a workflow centers on a custom package with methodology under development, users can make `targets` automatically watch the package's functions for changes. Simply supply the names of the relevant packages to the `imports` argument of `tar_option_set()`. Unlike `drake`, `targets` can track multiple packages this way, and the internal mechanism is much safer.

If you supply multiple packages,  e.g. `tar_option_set(imports = c("p1", "p2"))`, then the objects in `p1` override the objects in `p2` if there are name conflicts. Similarly, objects in `tar_option_get("envir")` override everything in `tar_option_get("imports")`.